### PR TITLE
Add more E2E test cases for Tooltip components

### DIFF
--- a/src/tests/e2e/components/AppHero.test.ts
+++ b/src/tests/e2e/components/AppHero.test.ts
@@ -33,6 +33,7 @@ test.describe("Hero icon buttons", () => {
       exact: true,
     });
     await expect(gitIcon).toBeVisible();
+    await expect(gitIcon).toHaveAttribute("data-state", "closed");
 
     await linkIcon.hover();
     await expect(
@@ -40,6 +41,7 @@ test.describe("Hero icon buttons", () => {
     ).toBeVisible();
 
     await gitIcon.hover();
+    await expect(gitIcon).toHaveAttribute("data-state", "open");
     await expect(
       page.getByAltText("GitHub Avatar image", {
         exact: true,

--- a/src/tests/e2e/components/AppSkills.test.ts
+++ b/src/tests/e2e/components/AppSkills.test.ts
@@ -9,12 +9,20 @@ test("Skills section heading, icons and lottie component", async ({
   page,
   isMobile,
 }) => {
-  await expect(page.getByRole("heading", { name: "💪Skills" })).toBeVisible();
-  await expect(page.getByLabel("TypeScript")).toBeVisible();
+  const skillsLottie = page.getByTestId("skillLottie");
+  const typeScriptIcon = page.getByLabel("TypeScript", { exact: true });
+
+  await expect(typeScriptIcon).toHaveAttribute("data-state", "closed");
+  await expect(typeScriptIcon).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "💪Skills", exact: true })
+  ).toBeVisible();
 
   if (isMobile) {
-    await expect(page.getByTestId("skillLottie")).toBeHidden();
+    await expect(skillsLottie).toBeHidden();
   } else {
-    await expect(page.getByTestId("skillLottie")).toBeVisible();
+    await typeScriptIcon.hover();
+    await expect(typeScriptIcon).toHaveAttribute("data-state", "delayed-open");
+    await expect(skillsLottie).toBeVisible();
   }
 });


### PR DESCRIPTION
# Describe your change(s)

Added more test cases to test the `Tooltip` attributes to check whether it changes when the respective icon is hovered. All test cases are added to both `AppHero` and `AppSkills` component.

## Type of change(s)

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

## Recordings / Screenshots (if any)
