### PR TITLE
Add tap events on mobile viewport and improve E2E tests

### DIFF
--- a/src/tests/e2e/app.test.ts
+++ b/src/tests/e2e/app.test.ts
@@ -5,23 +5,22 @@ test.beforeEach(async ({ page, goto }) => {
   await expect(page).toHaveTitle("Nicholas Yong's Portfolio");
 });
 
+test("Test dark mode switch", async ({ page }) => {
+  const themeButton = page.getByLabel("Appearance");
+  const faSun = page.getByTestId("sun");
+  const faMoon = page.getByTestId("moon");
+
+  await expect(themeButton).toBeInViewport();
+  await expect(faSun).toBeInViewport();
+  await expect(faMoon).toBeHidden();
+
+  await themeButton.click();
+  await expect(faSun).toBeHidden();
+  await expect(faMoon).toBeInViewport();
+});
+
 test.describe("Desktop viewport only", { tag: "@desktop" }, () => {
   test.skip(({ isMobile }) => isMobile);
-
-  test("Test dark mode switch", async ({ page }) => {
-    const themeButton = page.getByLabel("Appearance");
-    const faSun = page.getByTestId("sun");
-    const faMoon = page.getByTestId("moon");
-
-    await expect(themeButton).toBeInViewport();
-    await expect(faSun).toBeVisible();
-    await expect(faMoon).not.toBeVisible();
-
-    await themeButton.click();
-    await expect(faSun).not.toBeVisible();
-    await expect(faMoon).toBeVisible();
-  });
-
   test("Browser's scrollIntoView API", async ({ page }) => {
     const projectListItem = page
       .getByRole("listitem")
@@ -42,9 +41,9 @@ test.describe("Mobile viewport only", { tag: "@mobile" }, () => {
 
   test("Test navigation bar dropdown menu", async ({ page }) => {
     const dropdownContent = page.getByRole("menu");
-    await expect(dropdownContent).not.toBeVisible();
+    await expect(dropdownContent).toBeHidden();
 
     await page.getByRole("button", { expanded: false }).click();
-    await expect(dropdownContent).toBeVisible();
+    await expect(dropdownContent).toBeInViewport();
   });
 });

--- a/src/tests/e2e/components/AppContactMe.test.ts
+++ b/src/tests/e2e/components/AppContactMe.test.ts
@@ -18,23 +18,22 @@ test.describe("Contact me section testing", () => {
       }
     );
 
-    if (!isMobile) {
+    if (isMobile) {
+      await page.getByRole("button", { expanded: false }).tap();
+      await page.getByRole("menuitem").filter({ hasText: "Contact" }).tap();
+    } else {
       await page
         .getByRole("listitem")
         .filter({ hasText: "Contact" })
         .click({ button: "left" });
-
-      await expect(contactMeHeading).toBeInViewport();
-      await expect(contactMeButton).toBeInViewport();
-      await expect(contactMeButton).toHaveAttribute(
-        "href",
-        "mailto:nicholas8399@gmail.com"
-      );
-    } else {
-      await expect(contactMeHeading).toBeVisible();
-      await expect(contactMeButton).toBeVisible();
-      await expect(contactMeButton).toBeVisible();
     }
+
+    await expect(contactMeHeading).toBeInViewport();
+    await expect(contactMeButton).toBeInViewport();
+    await expect(contactMeButton).toHaveAttribute(
+      "href",
+      "mailto:nicholas8399@gmail.com"
+    );
   });
 
   test("Dark blue gradient dismount on dark mode", async ({ page }) => {

--- a/src/tests/e2e/components/AppProjects.test.ts
+++ b/src/tests/e2e/components/AppProjects.test.ts
@@ -17,22 +17,21 @@ test("App project section heading, and tooltip", async ({
     exact: true,
   });
 
-  if (!isMobile) {
+  if (isMobile) {
+    await page.getByRole("button", { expanded: false }).tap();
+    await page.getByRole("menuitem").filter({ hasText: "Projects" }).tap();
+    await expect(projectImage).toBeHidden();
+  } else {
     await page
       .getByRole("listitem")
       .filter({ hasText: "Projects" })
       .click({ button: "left" });
-
-    await expect(externalLink).toBeInViewport();
     await expect(externalLink).toHaveAttribute("data-state", "closed");
     await externalLink.hover();
     await expect(externalLink).toHaveAttribute("data-state", "delayed-open");
-
-    await expect(projectSubHeading).toBeInViewport();
     await expect(projectImage).toBeInViewport();
-  } else {
-    await expect(externalLink).toBeVisible();
-    await expect(projectSubHeading).toBeVisible();
-    await expect(projectImage).toBeHidden();
   }
+
+  await expect(projectSubHeading).toBeInViewport();
+  await expect(externalLink).toBeInViewport();
 });

--- a/src/tests/e2e/components/AppSkills.test.ts
+++ b/src/tests/e2e/components/AppSkills.test.ts
@@ -11,17 +11,23 @@ test("Skills section heading, icons and lottie component", async ({
   const skillsLottie = page.getByTestId("skillLottie");
   const psIcon = page.getByLabel("Photoshop", { exact: true });
   const psToolTip = page.getByText("Photoshop", { exact: true });
-
   await expect(psIcon).toHaveAttribute("data-state", "closed");
-  await expect(psIcon).toBeVisible();
-  await expect(psToolTip).toBeHidden();
 
   if (isMobile) {
+    await page.getByRole("button", { expanded: false }).tap();
+    await page.getByRole("menuitem").filter({ hasText: "Skills" }).tap();
     await expect(skillsLottie).toBeHidden();
   } else {
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Skills" })
+      .click({ button: "left" });
+    await expect(psToolTip).toBeHidden();
     await psIcon.hover();
     await expect(psIcon).toHaveAttribute("data-state", "delayed-open");
     await expect(psToolTip).toBeVisible();
-    await expect(skillsLottie).toBeVisible();
+    await expect(skillsLottie).toBeInViewport();
   }
+
+  await expect(psIcon).toBeInViewport();
 });

--- a/src/tests/e2e/components/AppWorkExperience.test.ts
+++ b/src/tests/e2e/components/AppWorkExperience.test.ts
@@ -9,18 +9,29 @@ test("Skills section heading, icons and lottie component", async ({
   await expect(page).toHaveTitle("Nicholas Yong's Portfolio");
 
   const experienceLottie = page.getByTestId("experienceLottie");
+  if (isMobile) {
+    await page.getByRole("button", { expanded: false }).tap();
+    await page.getByRole("menuitem").filter({ hasText: "Experience" }).tap();
+    await expect(experienceLottie).toBeHidden();
+  } else {
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Experience" })
+      .click({ button: "left" });
+    await expect(experienceLottie).toBeInViewport();
+  }
 
   await expect(
     page.getByRole("heading", {
       name: "A peek at my early career",
       exact: true,
     })
-  ).toBeVisible();
+  ).toBeInViewport();
   await expect(
     page.getByLabel("Click here to redirect to foodpanda website", {
       exact: true,
     })
-  ).toBeVisible();
+  ).toBeInViewport();
   await expect(
     page
       .getByLabel("Technologies used in foodpanda", {
@@ -28,10 +39,4 @@ test("Skills section heading, icons and lottie component", async ({
       })
       .getByRole("listitem")
   ).toHaveCount(5);
-
-  if (isMobile) {
-    await expect(experienceLottie).toBeHidden();
-  } else {
-    await expect(experienceLottie).toBeVisible();
-  }
 });


### PR DESCRIPTION
# Describe your change(s)

1. Using playwright tap events on mobile viewport so that I would not skip those mobile tests
2. Changing some assertions such as `.toBeVisible` to `.toBeInViewport`, since it makes more sense

## Type of change(s)

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

## Recordings / Screenshots (if any)
