### PR TITLE
Fix the CSS for the images under the 'Projects' section

### DIFF
--- a/src/components/AppProjects.vue
+++ b/src/components/AppProjects.vue
@@ -106,11 +106,11 @@ const columnPlacement = computed(() => {
           <aside
             :class="[
               { 'md:left-[45%]': checkIndex(value.id) },
-              'absolute left-0 top-0 -z-10 h-full max-h-[21.875rem] w-full opacity-[8%] md:top-1/4 md:h-1/2 md:w-1/2 md:max-w-[37.5rem] md:opacity-60 lg:top-[12.5%] lg:h-3/4 lg:w-1/2 dark:md:opacity-30',
+              'absolute left-0 top-0 -z-10 h-full max-h-[21.875rem] w-full overflow-y-clip opacity-[8%] md:top-1/4 md:h-1/2 md:w-1/2 md:max-w-[37.5rem] md:rounded-md md:border-2 md:border-black-200 md:opacity-60 lg:top-[12.5%] lg:h-3/4 lg:w-1/2 dark:md:opacity-30',
             ]"
           >
             <NuxtPicture
-              class="hidden md:inline-block md:rounded-md md:border-2 md:border-black-200"
+              class="hidden object-cover md:block"
               fit="cover"
               format="webp"
               loading="lazy"


### PR DESCRIPTION
# Describe your change(s)

- Fix the CSS for the images under the Projects section, it was previously overflowing past the parent container

## Type of change(s)

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

## Recordings / Screenshots (if any)
