### PR TITLE
Use runtime config for the GitHub GraphQL access token

### DIFF
--- a/src/components/AppHero.vue
+++ b/src/components/AppHero.vue
@@ -10,6 +10,7 @@ const mailIcon = iconAlias.get("mail")!;
 const locationIcon = iconAlias.get("location")!;
 
 const { data, status } = await getGithubViewer({
+  deep: false,
   getCachedData(key, nuxtApp) {
     return nuxtApp.payload.data[key] || nuxtApp.static.data[key];
   },

--- a/src/composables/execute.ts
+++ b/src/composables/execute.ts
@@ -17,6 +17,7 @@ export async function useExecute<TResult, TVariables>({
 }: ExecuteParams<TResult, TVariables>) {
   const {
     public: { githubBaseUrl },
+    githubSecret,
   } = useRuntimeConfig();
 
   return useAsyncData<{ data: TResult }>(key, () =>
@@ -24,7 +25,7 @@ export async function useExecute<TResult, TVariables>({
       method: "POST",
       headers: {
         Accept: "application/json",
-        Authorization: `Bearer ${process.env.NUXT_GITHUB_SECRET}`,
+        Authorization: `Bearer ${githubSecret}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({


### PR DESCRIPTION
# Describe your change(s)

Use runtime config for the GitHub GraphQL access token, it was previously using `process.env` which was incorrect.

## Type of change(s)

Please delete options that are not relevant.

- [X] Bugfix (non-breaking change which fixes an issue)

## Recordings / Screenshots (if any)
